### PR TITLE
game history scroll content inherits height

### DIFF
--- a/src/components/RoomView/roomView.css
+++ b/src/components/RoomView/roomView.css
@@ -55,7 +55,7 @@ body {
   font-weight: 400;
 }
 .scrollContent {
-  height: 300px;
+  height: inherit;
   font-size: 16px;
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
doesnt overflow anymore. tested at many screensizes
before->
<img width="304" alt="Screen Shot 2023-02-18 at 6 14 48 PM" src="https://user-images.githubusercontent.com/71895647/220147462-2c5623da-df99-4872-9856-d8a77317804a.png">
after->
<img width="288" alt="Screen Shot 2023-02-20 at 10 32 22 AM" src="https://user-images.githubusercontent.com/71895647/220147548-441b644e-2e6d-4aee-be28-bf7ec6ee0680.png">
